### PR TITLE
Add support for FlagSetOneVar and FlagSetManyVar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ matrix:
   fast_finish: true
 
 before_install:
-  - go get -v code.google.com/p/go.tools/cmd/vet
+  - go get -v golang.org/x/tools/cmd/vet
   - go get -v github.com/golang/lint/golint
-  - go get -v code.google.com/p/go.tools/cmd/cover
+  - go get -v golang.org/x/tools/cmd/cover
 
 install:
   - go install -race -v std

--- a/addrs.go
+++ b/addrs.go
@@ -32,13 +32,19 @@ func (f *flagOne) String() string {
 // FlagOneVar sets a single net.Addr by a flag. The value is expected to be a
 // colon separated net:host:port.
 func FlagOneVar(dest *net.Addr, name string, addr string, usage string) {
+	FlagSetOneVar(flag.CommandLine, dest, name, addr, usage)
+}
+
+// FlagSetOneVar sets a single net.Addr by a flag in a flag.FlagSet. The value
+// is expected to be a colon separated net:host:port.
+func FlagSetOneVar(set *flag.FlagSet, dest *net.Addr, name string, addr string, usage string) {
 	f := &flagOne{addr: dest}
 	if addr != "" {
 		if err := f.Set(addr); err != nil {
 			panic(err)
 		}
 	}
-	flag.Var(f, name, usage)
+	set.Var(f, name, usage)
 }
 
 type flagMany struct {
@@ -79,13 +85,19 @@ func (f *flagMany) String() string {
 // FlagManyVar sets a slice of net.Addr by a flag. The values are expected to
 // be comma separated list of net:host:port triples.
 func FlagManyVar(dest *[]net.Addr, name string, addrs string, usage string) {
+	FlagSetManyVar(flag.CommandLine, dest, name, addrs, usage)
+}
+
+// FlagSetManyVar sets a slice of net.Addr by a flag in a flag.FlagSet. The
+// values are expected to be comma separated list of net:host:port triples.
+func FlagSetManyVar(set *flag.FlagSet, dest *[]net.Addr, name string, addrs string, usage string) {
 	f := &flagMany{addrs: dest}
 	if addrs != "" {
 		if err := f.Set(addrs); err != nil {
 			panic(err)
 		}
 	}
-	flag.Var(f, name, usage)
+	set.Var(f, name, usage)
 }
 
 func resolveAddr(addr string) (net.Addr, error) {

--- a/addrs_test.go
+++ b/addrs_test.go
@@ -1,4 +1,4 @@
-package addrs_test
+package addrs
 
 import (
 	"flag"
@@ -6,8 +6,6 @@ import (
 	"net"
 	"sync"
 	"testing"
-
-	"github.com/facebookgo/flag.addrs"
 )
 
 var (
@@ -25,7 +23,7 @@ func genName() string {
 func TestFlagOne(t *testing.T) {
 	name := genName()
 	var a1 net.Addr
-	addrs.FlagOneVar(&a1, name, "", "")
+	FlagOneVar(&a1, name, "", "")
 
 	const network = "udp"
 	const addr = "127.0.0.1:1234"
@@ -44,7 +42,7 @@ func TestFlagOne(t *testing.T) {
 func TestFlagOneInvalidNetwork(t *testing.T) {
 	name := genName()
 	var a1 net.Addr
-	addrs.FlagOneVar(&a1, name, "", "")
+	FlagOneVar(&a1, name, "", "")
 
 	const network = "foo"
 	const addr = "127.0.0.1:1234"
@@ -63,7 +61,7 @@ func TestFlagOneDefaultValue(t *testing.T) {
 	var a1 net.Addr
 	const network = "udp"
 	const addr = "127.0.0.1:1234"
-	addrs.FlagOneVar(&a1, name, network+":"+addr, "")
+	FlagOneVar(&a1, name, network+":"+addr, "")
 	if a1.Network() != network {
 		t.Fatal("did not find expected network")
 	}
@@ -82,13 +80,13 @@ func TestFlagOneInvalidDefaultValue(t *testing.T) {
 	var a1 net.Addr
 	const network = "foo"
 	const addr = "127.0.0.1:1234"
-	addrs.FlagOneVar(&a1, name, network+":"+addr, "")
+	FlagOneVar(&a1, name, network+":"+addr, "")
 }
 
 func TestFlagOneInvalidFormat(t *testing.T) {
 	name := genName()
 	var a1 net.Addr
-	addrs.FlagOneVar(&a1, name, "", "")
+	FlagOneVar(&a1, name, "", "")
 
 	err := flag.Set(name, "foo")
 	if err == nil {
@@ -102,7 +100,7 @@ func TestFlagOneInvalidFormat(t *testing.T) {
 func TestFlagMany(t *testing.T) {
 	name := genName()
 	var a1 []net.Addr
-	addrs.FlagManyVar(&a1, name, "", "")
+	FlagManyVar(&a1, name, "", "")
 
 	const network0 = "tcp"
 	const addr0 = "127.0.0.1:1234"
@@ -133,7 +131,7 @@ func TestFlagManyDefaultValue(t *testing.T) {
 	const addr0 = "127.0.0.1:1234"
 	const network1 = "tcp"
 	const addr1 = "127.0.0.1:5678"
-	addrs.FlagManyVar(&a1, name, network0+":"+addr0+","+network1+":"+addr1, "")
+	FlagManyVar(&a1, name, network0+":"+addr0+","+network1+":"+addr1, "")
 
 	if a1[0].Network() != network0 {
 		t.Fatal("did not find expected network")
@@ -159,5 +157,5 @@ func TestFlagManyInvalidDefaultValue(t *testing.T) {
 	var a1 []net.Addr
 	const network = "foo"
 	const addr = "127.0.0.1:1234"
-	addrs.FlagManyVar(&a1, name, network+":"+addr, "")
+	FlagManyVar(&a1, name, network+":"+addr, "")
 }


### PR DESCRIPTION
This should make it possible to use this library with a *flag.FlagSet rather than requiring you to use the global flags. This makes it a bit easier to make testable packages which use this.
